### PR TITLE
header quasi auf das Cover geschoben

### DIFF
--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -246,7 +246,10 @@
   &__header {
     text-align: center;
     color: $color-black;
-
+    position: absolute;
+    margin: auto;
+    width: 100%;
+    z-index: 3;
   }
 
   &__excerptText{


### PR DESCRIPTION
so sieht man am desktop sofort das komplette Cover, soll außerdem ein bisschen kompakter wirken